### PR TITLE
Add GitHub Skills activity

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills with GitHub - part of our GitHub Certifications program to help with college applications",
+        "schedule": "Wednesdays, 3:30 PM - 5:00 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
## Description
This PR adds the GitHub Skills activity that was announced by the principal and is currently missing from the system.

## Changes
- Added "GitHub Skills" activity to the activities dictionary
- Description includes reference to GitHub Certifications program
- Schedule: Wednesdays, 3:30 PM - 5:00 PM
- Capacity: 25 students
- Ready for student registrations

## Resolves
Closes #6

## Testing
- ✅ Verified Python syntax is correct
- ✅ Confirmed activity is properly added (total activities: 10)
- ✅ Activity appears with correct details

## Impact
- Students can now sign up for the GitHub Skills activity before the registration deadline
- Supports the GitHub Certifications program for college applications